### PR TITLE
Document the message format for the RSA signing

### DIFF
--- a/src/crypto_traits.rs
+++ b/src/crypto_traits.rs
@@ -80,6 +80,28 @@ pub trait Rsa2048Pkcs1v15: CryptoClient {
         })
     }
 
+    /// Sign a precomputed hash of the message.
+    ///
+    /// Message should be sent in a PKCS#1's Digestinfo format: OID || hash.
+    /// Backend will add the required PKCS1v1.5 padding.
+    /// Excerpt from <https://www.rfc-editor.org/rfc/rfc8017#page-47>:
+    /// ```text
+    /// SHA-1:   (0x)30 21 30 09 06 05 2b 0e 03 02 1a 05 00 04 14 || H.
+    /// SHA-224:  (0x)30 2d 30 0d 06 09 60 86 48 01 65 03 04 02 04
+    ///              05 00 04 1c || H.
+    /// SHA-256: (0x)30 31 30 0d 06 09 60 86 48 01 65 03 04 02 01 05 00
+    ///              04 20 || H.
+    /// SHA-384: (0x)30 41 30 0d 06 09 60 86 48 01 65 03 04 02 02 05 00
+    ///              04 30 || H.
+    /// SHA-512: (0x)30 51 30 0d 06 09 60 86 48 01 65 03 04 02 03 05 00
+    ///              04 40 || H.
+    ///```
+    /// # Arguments
+    ///
+    /// * `key`: the keyid to be used
+    /// * `message`: a Digestinfo structure: "hash_oid || hash"
+    ///
+    /// returns: Result<FutureResult<Sign, Self>, ClientError>
     fn sign_rsa2048pkcs<'c>(
         &'c mut self,
         key: KeyId,
@@ -199,6 +221,28 @@ pub trait Rsa3072Pkcs1v15: CryptoClient {
         })
     }
 
+    /// Sign a precomputed hash of the message.
+    ///
+    /// Message should be sent in a PKCS#1's Digestinfo format: OID || hash.
+    /// Backend will add the required PKCS1v1.5 padding.
+    /// Excerpt from <https://www.rfc-editor.org/rfc/rfc8017#page-47>:
+    /// ```text
+    /// SHA-1:   (0x)30 21 30 09 06 05 2b 0e 03 02 1a 05 00 04 14 || H.
+    /// SHA-224:  (0x)30 2d 30 0d 06 09 60 86 48 01 65 03 04 02 04
+    ///              05 00 04 1c || H.
+    /// SHA-256: (0x)30 31 30 0d 06 09 60 86 48 01 65 03 04 02 01 05 00
+    ///              04 20 || H.
+    /// SHA-384: (0x)30 41 30 0d 06 09 60 86 48 01 65 03 04 02 02 05 00
+    ///              04 30 || H.
+    /// SHA-512: (0x)30 51 30 0d 06 09 60 86 48 01 65 03 04 02 03 05 00
+    ///              04 40 || H.
+    ///```
+    /// # Arguments
+    ///
+    /// * `key`: the keyid to be used
+    /// * `message`: a Digestinfo structure: "hash_oid || hash"
+    ///
+    /// returns: Result<FutureResult<Sign, Self>, ClientError>
     fn sign_rsa3072pkcs<'c>(
         &'c mut self,
         key: KeyId,
@@ -318,6 +362,28 @@ pub trait Rsa4096Pkcs1v15: CryptoClient {
         })
     }
 
+    /// Sign a precomputed hash of the message.
+    ///
+    /// Message should be sent in a PKCS#1's Digestinfo format: OID || hash.
+    /// Backend will add the required PKCS1v1.5 padding.
+    /// Excerpt from <https://www.rfc-editor.org/rfc/rfc8017#page-47>:
+    /// ```text
+    /// SHA-1:   (0x)30 21 30 09 06 05 2b 0e 03 02 1a 05 00 04 14 || H.
+    /// SHA-224:  (0x)30 2d 30 0d 06 09 60 86 48 01 65 03 04 02 04
+    ///              05 00 04 1c || H.
+    /// SHA-256: (0x)30 31 30 0d 06 09 60 86 48 01 65 03 04 02 01 05 00
+    ///              04 20 || H.
+    /// SHA-384: (0x)30 41 30 0d 06 09 60 86 48 01 65 03 04 02 02 05 00
+    ///              04 30 || H.
+    /// SHA-512: (0x)30 51 30 0d 06 09 60 86 48 01 65 03 04 02 03 05 00
+    ///              04 40 || H.
+    ///```
+    /// # Arguments
+    ///
+    /// * `key`: the keyid to be used
+    /// * `message`: a Digestinfo structure: "hash_oid || hash"
+    ///
+    /// returns: Result<FutureResult<Sign, Self>, ClientError>
     fn sign_rsa4096pkcs<'c>(
         &'c mut self,
         key: KeyId,

--- a/src/crypto_traits.rs
+++ b/src/crypto_traits.rs
@@ -82,8 +82,7 @@ pub trait Rsa2048Pkcs1v15: CryptoClient {
 
     /// Sign a precomputed hash of the message.
     ///
-    /// Message should be sent in a PKCS#1's Digestinfo format: OID || hash.
-    /// Backend will add the required PKCS1v1.5 padding.
+    /// Message should be sent in a PKCS#1's Digestinfo format: `OID || hash`.
     /// Excerpt from <https://www.rfc-editor.org/rfc/rfc8017#page-47>:
     /// ```text
     /// SHA-1:   (0x)30 21 30 09 06 05 2b 0e 03 02 1a 05 00 04 14 || H.
@@ -96,6 +95,9 @@ pub trait Rsa2048Pkcs1v15: CryptoClient {
     /// SHA-512: (0x)30 51 30 0d 06 09 60 86 48 01 65 03 04 02 03 05 00
     ///              04 40 || H.
     ///```
+    ///
+    /// The backend will add the required PKCS1v1.5 padding.
+    ///
     /// # Arguments
     ///
     /// * `key`: the keyid to be used
@@ -223,8 +225,7 @@ pub trait Rsa3072Pkcs1v15: CryptoClient {
 
     /// Sign a precomputed hash of the message.
     ///
-    /// Message should be sent in a PKCS#1's Digestinfo format: OID || hash.
-    /// Backend will add the required PKCS1v1.5 padding.
+    /// Message should be sent in a PKCS#1's Digestinfo format: `OID || hash`.
     /// Excerpt from <https://www.rfc-editor.org/rfc/rfc8017#page-47>:
     /// ```text
     /// SHA-1:   (0x)30 21 30 09 06 05 2b 0e 03 02 1a 05 00 04 14 || H.
@@ -237,6 +238,9 @@ pub trait Rsa3072Pkcs1v15: CryptoClient {
     /// SHA-512: (0x)30 51 30 0d 06 09 60 86 48 01 65 03 04 02 03 05 00
     ///              04 40 || H.
     ///```
+    ///
+    /// The backend will add the required PKCS1v1.5 padding.
+    ///
     /// # Arguments
     ///
     /// * `key`: the keyid to be used
@@ -364,8 +368,7 @@ pub trait Rsa4096Pkcs1v15: CryptoClient {
 
     /// Sign a precomputed hash of the message.
     ///
-    /// Message should be sent in a PKCS#1's Digestinfo format: OID || hash.
-    /// Backend will add the required PKCS1v1.5 padding.
+    /// Message should be sent in a PKCS#1's Digestinfo format: `OID || hash`.
     /// Excerpt from <https://www.rfc-editor.org/rfc/rfc8017#page-47>:
     /// ```text
     /// SHA-1:   (0x)30 21 30 09 06 05 2b 0e 03 02 1a 05 00 04 14 || H.
@@ -378,6 +381,9 @@ pub trait Rsa4096Pkcs1v15: CryptoClient {
     /// SHA-512: (0x)30 51 30 0d 06 09 60 86 48 01 65 03 04 02 03 05 00
     ///              04 40 || H.
     ///```
+    ///
+    /// The backend will add the required PKCS1v1.5 padding.
+    ///
     /// # Arguments
     ///
     /// * `key`: the keyid to be used


### PR DESCRIPTION
Document the message format for the RSA signing. Specifically mention the need for the hash OID, which prefixes the digest.